### PR TITLE
Architecture and Beta Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,45 +10,49 @@ This repository contains the Docker Compose file used to launch the OHDSI gaiaDo
 
 - the OHDSI GIS gaia stack [ with: --profile gaia ]
   - gaia-core  
-    Hades based R environment with additional GIS toolchain
+    Hades based R environment with additional GIS toolchain  
 	- gaia-db  
-	  postgis relational database as GIS datastore
+	  postgis relational database as GIS datastore  
 	- gaia-catalog  
-	  python flask app as an interface to gaia-solr at [http://localhost:5000](http://localhost:5000)
+	  python flask app as an interface to gaia-solr at [http://localhost:5000](http://localhost:5000)  
 	- gaia-osgeo  
-	  gdal/ogr toolset for ETL
+	  gdal/ogr toolset for ETL  
 	- gaia-postgis  
-	  postgis toolset for ETL
+	  postgis toolset for ETL  
 	- gaia-git  
 	  git for using external code
-	- gaia-gdsc 
-	  python environment for data processing
+	- gaia-gdsc  
+	  python environment for data processing  
 	- gaia-solr  
-	  solr index of all catalog entries at [http://localhost:8983](http://localhost:8983)
--  additional tools [ optional ] [ with: --profile degauss ]
+	  solr index of all catalog entries at [http://localhost:8983](http://localhost:8983)  
+-  additional tools [ optional ] [ with: --profile degauss ]  
 	- gaia-degauss  
-	  degauss geocoder for adding lat/lon to address information 
+	  degauss geocoder for adding lat/lon to address information  
 
-This repository is based on the [OHDSI Broadsea](https://github.com/OHDSI/Broadsea) implementation with future integration in mind.
+This repository is based on the [OHDSI Broadsea](https://github.com/OHDSI/Broadsea) implementation with future integration in mind.  
 
-### A Note on Docker Compose V2
+### A Note on Docker Compose V2  
 
-Throughout this README, we will show docker compose commands with the convention of `docker compose` (no hyphen), per the new Docker Compose V2 standard outlined by [Docker](https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose).
+Throughout this README, we will show docker compose commands with the convention of `docker compose` (no hyphen), per the new Docker Compose V2 standard outlined by [Docker](https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose).  
 
-**For gaiaDocker, you will need Docker version 1.27.0+.**
+**For gaiaDocker, you will need Docker version 1.27.0+.**  
 
-### Dependencies
+### Dependencies  
 
 - Linux, Mac, or Windows with WSL
 - Docker 1.27.0+
 - Git
 - Chromium-based web browser (Chrome, Edge, etc.)
 
-### Mac Silicon
+### Secrets  
 
-If using Mac Silicon (M1, M2, etc), you **may** need to set the DOCKER_ARCH variable in Section 1 of the .env file to "linux/arm64" (line 5). Some Broadsea services still need to run via emulation of linux/amd64 and are hard-coded as such.
+All secrets are in the top-level secrets folder. For gaiaDocker there is a gaia subfolder with gaia specific secrets. Note that syou should change your internal secrets (postgres, internal API, etc) and that you will need to provide your own external API secrets (Copernicus, Census, Earth Explorer, and so on).  
 
-## gaiaDocker - Quick start
+### Mac Silicon  
+
+If using Mac Silicon (M1, M2, etc), you **may** need to set the DOCKER_ARCH variable in Section 1 of the .env file to "linux/arm64" (line 5). Some Broadsea services still need to run via emulation of linux/amd64 and are hard-coded as such.  
+
+## gaiaDocker - Quick start  
 
 - Download and install Docker. See the installation instructions at the [Docker Web Site](https://docs.docker.com/engine/installation/ "Install Docker")
 - git clone this GitHub repo:
@@ -75,7 +79,7 @@ docker-compose --profile gaia up -d
 - The first time the above command is run it will take several mintues for the containers to build.
 - The containers will run and you can explore, but there is no functionality yet (stay tuned).
 
-## gaiaDocker - Quick end
+## gaiaDocker - Quick end  
 
 - In the directory where this README.md is located, in a command line / terminal window, use the below command to terminate the containers.  
 

--- a/secrets/gaia/COPERNICUS_EXAMPLE_KEY
+++ b/secrets/gaia/COPERNICUS_EXAMPLE_KEY
@@ -1,4 +1,5 @@
-# you must:
+# you will benefit by doing the following:
+# - see instructions here: https://cds.climate.copernicus.eu/how-to-api
 # - replace <your copernicus key here> with your key
 # - delete all commented lines
 # - save as COPERNICUS_KEY


### PR DESCRIPTION
## Beta Version of gaiaDocker. 

This pull request provides some documentation for the beta version of gaiaDocker. This version of gaiaDocker builds all of the docker containers at runtime. This makes debugging and container optimization easier than building and pushing to docker hub and the re-pulling the images for every modification. As the architecture matures, we can use the build-dev branch to continue to build at runtime and move the prebuilt environment into the main branch. Also note that for this first draft, most of the build contexts are at the root level of this repository, but some build contexts rely on the [ohdsi/GIS](https://github.com/OHDSI/GIS) and [gdsc/docker](https://github.com/Geospatial-Digital-Special-Collections/docker) repositories. This is not a permanent choice, but instead a way to reference prior work in this space.

The documentation is outlined as:  

- Overview of Approach
- Container Architecture
- API Notes
- Missing Pieces

### Overview of Approach

The fundamental requirements that drive the vision behind this draft are:

- Provide a containerized environment for end-to-end GIS data processing pipeline to enable analysis of patient outcomes with the [OHDSI/GIS toolchain](https://ohdsi.github.io/GIS/index.html#GIS_Toolchain)
- Use standard GIS processing tools with a focus on the command line [GDAL/OGR](https://gdal.org/en/stable/) processing libraries and SQL only approaches in [PostGIS](https://postgis.net/).
- Provide a data catalog with sufficient metadata descriptions of specific datasets to meet the above two requirements.

This draft follows the architectural approach from [OHDSI/Broadsea](https://github.com/OHDSI/Broadsea) to meet these requirements. Docker compose is used to spin up several containers that communicate with one and another through specific APIs across the local docker network. The user interacts with the containers through RStudio running on gaia-core and the data catalog as a Flask app running on gaia-catalog. The containers are categorized as ETL, catalog, database, and RStudio. There is a sidecar degauss container that can be used for geocoding patient locations (with more options to follow). **NOTE:** the current configuration is **not** stable on all systems.

The user chooses data from the catalog interface running on gaia-catalog by clicking on the red dot next to the data set name which initiates the ETL pipeline for that data set. The gaia-catalog container then runs shell and SQL scripts on the ETL containers to move the data from its source (most likely somewhere on the internet) into the gaiaDB PostGIS data base on the gaia-db container. The shell and SQL scripts can be created by hand (tedious) or by using the metadata provided in the catalog to parameterize the scripts using the [GDSC tools](https://github.com/Geospatial-Digital-Special-Collections/tools). This process is still beta, but it should stabilize in the coming months with help from this group.

The metadata provided in the gaiaDocker/datastore (to be moved to the gaiaCatalog repository) is organized into two directories: *collections* and *data*. The *collections* directory contains descriptions for multiple data sets identified as a collection. The *data* directory is organized into subdirectories labeled by the data set name. Currently the naming convention is loosely defined as (but there are exceptions):
```
<place abbreviation>_[<year of publication if static>_]<data set name>_<source agency>
```
Inside each data set directory are three metadata descriptions: etl, dcat, and jsonld. At this moment these metadata descriptions are functional drafts that need much improvement. Only etl (for ETL) and dcat (for catalog) are currently used; json-ld is not yet implemented. Both the collection level and dataset level descriptions are used by the SOLR instance running on gaia-solr to build indexes that are used for the search and display functionality in the catalog interfacce on gaia-catalog. This datastore is mounted into the etl container group and the gaia-solr and gaia-catalog containers as a local volume on the host computer. As data is processed through the pipeline, the source data is stored in the *download* subdirectory in its respective directory for persistence. Other information and code is also stored locally in  subdirectories as needed (for example custom code from github is stored in the *scripts* subfolder).

At the end of the current processing pipeline the data set of choice resides in the public schema of the gaiaDB database on the gaia-db container with minimal transformations from the source data. The data can be loaded and visualized by connecting to the gaioaDB database on the gaia-db container on the port specified in the .env file (top-level directory) and the postgres_password in the secrets/gaia/ directory  with any number of database clients such as RStudio, QGIS, and pgAdmin. **NOTE:** the final step to transform the data into the OHDSI/GIS schema is not yet in place, but can be implemented with SQL only processing (likely two SELECT INTO statements; one for the geom table and the other for the attr table).

### Container Architecture. 

![gaiaDocker](https://github.com/user-attachments/assets/801c5925-6141-4756-8338-8303745e11da)

### API Notes

Docker does not provide an native API to allow a process on one container to communicate with a process on another container. For the most part this is not a problem as many of the components of the OHDSI/GIS toolchain provide APIs that work across the docker network; for example RStudio, PostGIS, and SOLR. For those components that do not have APIs, such as the ETL containers with GDAL, git, psql, and python, I implemented a re-useable shell based ucspi-tcp API found in the ./api directory. This functions for now, but could be changed to anything else as needed.

### Missing Pieces

So many .... but here is an immediate short list:  

- general
   - build all containers and move to OHDSI dockerhub 
   - finalize locations of docker contexts and Dockerfiles
- gaia-db
   - check for existence before etl
   - final step to transform into OHDSI/GIS schema
   - integrate with more recent vocabulary work
- gaia-catalog
   - move to separate repository and update Dockerfile(s) as needed
   - update metadata on disk and solr index after ETL
   - implement json-ld
- gaia-solr
   - re-index on the fly
- gaia-gdsc
   - how to handle multiple api secrets for data download from different sources
- gaia-git
   - clone vs pull if repository already exists

Considerations as we move forward  

- Combine all ETL containers into one?? There are trade-offs on maintenance, elegance, and security to consider ...
- Seek alternative to GDSC tools for automatic shell and SQL script generation? The GDSC tools more or less work (with minor manual interventions that can be removed), but perhaps there are other alternatives.


